### PR TITLE
LocalStack hack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build: clean
 
 clean:
 	-rm -rf _output
-	-docker system prune --all --force
+#	-docker system prune --all --force
 
 docker-login:
 	aws --region $(AWS_REGION) $(ECRCMD) get-login-password | docker login -u AWS --password-stdin $(REPOBASE)
@@ -44,7 +44,6 @@ docker-buildx:
 	$(foreach ARCH,$(ARCHITECTURES),docker buildx build \
                 --platform $(GOOS)/$(ARCH) \
                 --no-cache \
-                --push \
                 -t $(REGISTRY_NAME):latest-$(ARCH) \
                 -t $(REGISTRY_NAME):latest-$(GOOS)-$(ARCH) \
                 -t $(REGISTRY_NAME):$(FULL_REV)-$(GOOS)-$(ARCH) \

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -48,6 +48,7 @@ func NewAuth(
 	if !usePodIdentity {
 		// Get an initial session to use for STS calls when using IRSA
 		sess, err := session.NewSession(aws.NewConfig().
+			WithEndpoint("http://localhost.localstack.cloud:4566").
 			WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint).
 			WithRegion(region),
 		)

--- a/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/templates/daemonset.yaml
@@ -52,11 +52,15 @@ spec:
             - name: mountpoint-dir
               mountPath: {{ .Values.kubeletPath }}/pods
               mountPropagation: HostToContainer
-          {{- if or .Values.useFipsEndpoint .Values.awsRegion }}
+          {{- if or .Values.useFipsEndpoint .Values.awsRegion .Values.awsEndpointUrl }}
           env:
             {{- if .Values.useFipsEndpoint }}
             - name: AWS_USE_FIPS_ENDPOINT
               value: {{ .Values.useFipsEndpoint | quote }}
+            {{- end }}
+            {{- if .Values.awsEndpointUrl }}
+            - name: AWS_ENDPOINT_URL
+              value: {{ .Values.awsEndpointUrl | quote }}
             {{- end }}
             {{- if .Values.awsRegion }}
             - name: AWS_REGION

--- a/charts/secrets-store-csi-driver-provider-aws/values.yaml
+++ b/charts/secrets-store-csi-driver-provider-aws/values.yaml
@@ -4,6 +4,7 @@ image:
   tag: 1.0.r2-96-gfeeb3ac-2025.05.06.20.19
 
 awsRegion: ""
+awsEndpointUrl: ""
 nameOverride: ""
 fullnameOverride: ""
 providerVolume: "/var/run/secrets-store-csi-providers"

--- a/credential_provider/irsa_credential_provider.go
+++ b/credential_provider/irsa_credential_provider.go
@@ -61,6 +61,7 @@ func (p *IRSACredentialProvider) GetAWSConfig() (*aws.Config, error) {
 
 	return aws.NewConfig().
 		WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint).
+		WithEndpoint("http://localhost.localstack.cloud:4566").
 		WithRegion(p.region).
 		WithCredentials(credentials.NewCredentials(ar)), nil
 }

--- a/test_localstack.sh
+++ b/test_localstack.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+    read -p "Please enter the cluster container name: " cluster_container_name
+else
+    cluster_container_name=$1
+fi
+
+export PRIVREPO=localhost/aws-secrets-manager/secrets-store-csi-driver-provider-aws
+export TAG=latest-arm64
+export PLATFORM=linux/arm64
+export NAMESPACE=bitwarden
+make build
+make docker-buildx
+docker save $PRIVREPO:$TAG --platform=$PLATFORM > image.tar
+docker cp image.tar $cluster_container_name:/tmp/image.tar
+docker exec -it $cluster_container_name sh -c "ctr images rm $PRIVREPO:$TAG || true"
+docker exec -it $cluster_container_name sh -c "ctr images import /tmp/image.tar"
+docker exec -it $cluster_container_name sh -c "ctr images list | grep $PRIVREPO"
+
+
+helm uninstall aws-secrets-manager || true
+helm upgrade --install aws-secrets-manager charts/secrets-store-csi-driver-provider-aws --namespace $NAMESPACE --set awsEndpointUrl=http://localhost.localstack.cloud:4566 --set image.repository=$PRIVREPO --set image.tag=$TAG


### PR DESCRIPTION
###WIP

This currently hardcodes in the localstack endpoint for testing.
The long term is that the helm chart should provide the ability to override.

For local testing, a `test_localstack.sh` script was created, which does the following:
1. Builds the code
2. Builds the docker image
3. Copies the docker image into the local cluster container
4. (Re)installs the helm chart, which will pull in the custom built image